### PR TITLE
world border support and target 1.9 to 1.12 now

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 
-archivesBaseName = "${project.mod_id}-${project.minecraft_version}"
+archivesBaseName = "${project.mod_id}-1.9-1.12.2"
 version = "${getVersionMetadata()}"
 
 loom {

--- a/src/main/java/net/set/spawn/mod/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/net/set/spawn/mod/mixin/ServerPlayerEntityMixin.java
@@ -45,7 +45,7 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
                 if (j <= 1) {
                     radius = 1;
                 }
-                if (Math.abs(xFloor - spawnPos.getX()) > 10 || Math.abs(zFloor - spawnPos.getZ()) > 10) {
+                if (Math.abs(xFloor - spawnPos.getX()) > radius || Math.abs(zFloor - spawnPos.getZ()) > radius) {
                     SetSpawn.shouldSendErrorMessage = true;
                     response = "The X or Z coordinates given (" + seedObject.getX() + ", " + seedObject.getZ() + ") are more than 10 blocks away from the world spawn. Not overriding player spawnpoint.";
                     SetSpawn.errorMessage = response;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "${mod_id}",
   "version": "${version}",
-  "name": "Set Spawn 1.12.2",
+  "name": "Set Spawn 1.9-1.12.2",
   "description": "Sets the player's spawnpoint in SSG to specified coordinates.",
   "authors": [
     "bdamja",
@@ -25,7 +25,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.12.12",
-    "minecraft": "1.12.2"
+    "minecraft": ">=1.9 <=1.12.2"
   },
   "breaks": {
     "worldpreview": "*"


### PR DESCRIPTION
## Description
- Uses radius in the check for if the spawn point is valid because otherwise there's just a bunch of useless code and also vanilla parity for the world border I guess
- Broadened the scope of support to 1.9 to 1.12 because the mod already supported those versions, it just had a dependency on strictly 1.12.12 prior

Checklist
- [x] Build compiles and is ready to be automatically be released to the public
